### PR TITLE
Use jitpack for the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 You can use this repository as base for your external plugins, and host it on GitHub to make your external plugins available for everybody through the external manager plugin panel in the OpenOSRS client.
 
-First of all you need to build the client (refer to the steps in this [guide][1])
-After building you need to upload all the artifacts to your local maven repository.
-You can do this within intellij by going to the gradle panel at the right hand side and click on OpenOSRS -> Tasks -> publishing -> publishToMavenLocal
+This pulls down the latest snapshot for OpenOSRS, which is hosted through [jitpack.io](https://jitpack.io). This means you don't need to maintain that locally. This will be changed to an actual version when versioning actually works with OpenOSRS and Jitpack.
 
 In this repository you'll find two examples one is written in kotlin and the other one is written in java.
 Before you start you need to make a couple changes:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ project.extra["GithubUrl"] = "http://github.com/<INSERT NAME>/<INSERT REPOSITORY
 
 apply<BootstrapPlugin>()
 
+allprojects {
+    repositories {
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+
 subprojects {
     group = "com.example"
 
@@ -28,7 +34,9 @@ subprojects {
 
         exclusiveContent {
             forRepository {
-                mavenLocal()
+                maven {
+                    url = uri("https://jitpack.io")
+                }
             }
             filter {
                 includeGroupByRegex("com\\.openosrs.*")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,6 @@
  */
 
 object ProjectVersions {
-    const val openosrsVersion = "3.0.7"
     const val apiVersion = "0.0.1"
 }
 

--- a/javaexample/javaexample.gradle.kts
+++ b/javaexample/javaexample.gradle.kts
@@ -1,5 +1,3 @@
-import ProjectVersions.openosrsVersion
-
 /*
  * Copyright (c) 2019 Owain van Brakel <https://github.com/Owain94>
  * All rights reserved.
@@ -34,8 +32,8 @@ dependencies {
     annotationProcessor(Libraries.lombok)
     annotationProcessor(Libraries.pf4j)
 
-    compileOnly("com.openosrs:runelite-api:$openosrsVersion+")
-    compileOnly("com.openosrs:runelite-client:$openosrsVersion+")
+    implementation("com.github.open-osrs.runelite:runelite-api:-SNAPSHOT")
+    implementation("com.github.open-osrs.runelite:runelite-client:-SNAPSHOT")
 
     compileOnly(Libraries.guice)
     compileOnly(Libraries.javax)

--- a/kotlinexample/kotlinexample.gradle.kts
+++ b/kotlinexample/kotlinexample.gradle.kts
@@ -1,5 +1,3 @@
-import ProjectVersions.openosrsVersion
-
 /*
  * Copyright (c) 2019 Owain van Brakel <https://github.com/Owain94>
  * All rights reserved.
@@ -40,8 +38,8 @@ dependencies {
 
     kapt(Libraries.pf4j)
 
-    compileOnly("com.openosrs:runelite-api:$openosrsVersion+")
-    compileOnly("com.openosrs:runelite-client:$openosrsVersion+")
+    implementation("com.github.open-osrs.runelite:runelite-api:-SNAPSHOT")
+    implementation("com.github.open-osrs.runelite:runelite-client:-SNAPSHOT")
 
     compileOnly(Libraries.guice)
     compileOnly(Libraries.javax)


### PR DESCRIPTION
I see that you need to compile openrs locally, and it uses that for its local maven cache (mavenLocal).

Using jitpack we can download the latest snapshot, I'm unsure if we can version pin given that the builds don't line up? Maybe we need to commit pin?

Thoughts about this @Owain94 ?