### PR TITLE
Update example to work with updated OPRS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 You can use this repository as base for your external plugins, and host it on GitHub to make your external plugins available for everybody through the external manager plugin panel in the OpenOSRS client.
 
+This has been updated for the new OPRS client version 4.0+.
+
 First of all you need to build the client (refer to the steps in this [guide][1])
 After building you need to upload all the artifacts to your local maven repository.
 You can do this within intellij by going to the gradle panel at the right hand side and click on OpenOSRS -> Tasks -> publishing -> publishToMavenLocal
@@ -17,7 +19,7 @@ Before you start you need to make a couple changes:
 The file "{project}/{projectname}.gradle.kts" (for example "javaexample/javaexample.gradle.kts") has two values you'll need to change "project.extra["PluginName"]" and "project.extra["PluginDescription"]"
 
 After building your project you can find the plugin jar in the build/libs folder of that project.
-This jar can be used directly by copying it into the "externalmanager" folder in the ".runelite" directory.
+This jar can be used directly by copying it into the "plugins" folder in the ".openosrs" directory: `USER/.openosrs/plugins`.
 
 If you want to bootstrap your plugins to make them available on GitHub you can just easily run the following task from the gradle panel in intellij Tasks -> other -> bootstrapPlugin
 This will copy your plugin to the release folder in the main directory and fill the plugins.json file with the needed information.

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,7 +24,7 @@
  */
 
 object ProjectVersions {
-    const val openosrsVersion = "3.4.2"
+    const val openosrsVersion = "4.0.0"
     const val apiVersion = "0.0.1"
 }
 

--- a/javaexample/src/main/java/com/example/javaexample/JavaExamplePlugin.java
+++ b/javaexample/src/main/java/com/example/javaexample/JavaExamplePlugin.java
@@ -8,14 +8,12 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.PluginType;
 import org.pf4j.Extension;
 
 @Extension
 @PluginDescriptor(
 	name = "Java example",
-	description = "Java example",
-	type = PluginType.MISCELLANEOUS
+	description = "Java example"
 )
 @Slf4j
 public class JavaExamplePlugin extends Plugin

--- a/kotlinexample/src/main/kotlin/com/example/kotlinexample/KotlinExamplePlugin.kt
+++ b/kotlinexample/src/main/kotlin/com/example/kotlinexample/KotlinExamplePlugin.kt
@@ -6,15 +6,13 @@ import net.runelite.client.config.ConfigManager
 import net.runelite.client.eventbus.Subscribe
 import net.runelite.client.plugins.Plugin
 import net.runelite.client.plugins.PluginDescriptor
-import net.runelite.client.plugins.PluginType
 import org.pf4j.Extension
 import javax.inject.Inject
 
 @Extension
 @PluginDescriptor(
         name = "Kotlin example",
-        description = "Kotlin example",
-        type = PluginType.MISCELLANEOUS
+        description = "Kotlin example"
 )
 class KotlinExamplePlugin : Plugin() {
 


### PR DESCRIPTION
Updates the example plugin to work with the upcoming change to OpenOSRS client as Runelite fork.